### PR TITLE
Switch mailing lists URL

### DIFF
--- a/data/contact.yml
+++ b/data/contact.yml
@@ -10,7 +10,7 @@ after_email: |
   </p>
   <p>
       You are also welcome to join the <a
-      href="https://framalistes.org/sympa/info/openrail-general"
+      href="https://lists.openrailassociation.org/postorius/lists/general.lists.openrailassociation.org/"
       target="_blank">OpenRail mailing list</a> for general discussions and
       announcements. This is the best way to be informed about updates.
   </p>


### PR DESCRIPTION
We're migrating to our own mailing list infrastructure. This publishes the new address.