### PR TITLE
Deploy preview for pull requests on separate URL

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -133,3 +134,12 @@ jobs:
           source: "public/*"
           rm: true
           strip_components: 1
+
+      - name: Inform about Preview URL
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          header: pr-preview
+          message: |
+            Pull Request Live Preview
+            :---:
+            | <p><br />:rocket: View preview at <br />https://${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}/<br /></p>

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -7,6 +7,11 @@ on:
 
   # Run on PRs, but only build
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -33,9 +38,24 @@ env:
   uberspace_virtual_base: /var/www/virtual
 
 jobs:
+  # Set vars
+  vars:
+    runs-on: ubuntu-22.04
+    outputs:
+      pr_closed_merged: ${{ steps.pr_status.outputs.pr_closed_merged }}
+      datetime: ${{ steps.datetime.outputs.datetime }}
+    steps:
+      - id: pr_status
+        run: echo "pr_closed_merged=${{ github.event.pull_request.closed_at || github.event.pull_request.merged }}" >> "$GITHUB_OUTPUT"
+      - id: datetime
+        run: echo "datetime=$(date '+%Y-%m-%d %H:%M:%S %Z')" >> "$GITHUB_OUTPUT"
+
   # Build job
   build:
     runs-on: ubuntu-22.04
+    needs: vars
+    # Only if PR not closed or merged
+    if: needs.vars.outputs.pr_closed_merged == 'false'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,12 +105,14 @@ jobs:
   #         # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
 
   # Deployment jobs
-  deploy:
+  deploy-production:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
-    needs: build
+    needs:
+      - vars
+      - build
     # Only deploy if on main branch
     if: github.ref == 'refs/heads/main'
     steps:
@@ -111,9 +133,11 @@ jobs:
 
   deploy-preview:
     runs-on: ubuntu-22.04
-    needs: build
-    # Only deploy if pull request
-    if: ${{ github.event.pull_request }}
+    needs:
+      - vars
+      - build
+    # Only deploy if non-closed/non-merged pull request
+    if: github.event.pull_request && needs.vars.outputs.pr_closed_merged == 'false'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -142,4 +166,38 @@ jobs:
           message: |
             Pull Request Live Preview
             :---:
-            | <p><br />:rocket: View preview at <br />https://${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}/<br /></p>
+            | <p><br />:rocket: View preview at <br />https://${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}/<br /><br /></p>
+            | <p>Last updated: ${{ needs.vars.outputs.datetime }}</p>
+
+  remove-preview:
+    runs-on: ubuntu-22.04
+    needs:
+      - vars
+    # Only deploy if non-closed/non-merged pull request
+    if: github.event.pull_request && needs.vars.outputs.pr_closed_merged != 'false'
+    steps:
+      - name: Create deletion notice
+        run: mkdir -p public && echo "This PR has been closed or merged. The preview has been removed." > public/index.html
+
+      - name: Copy empty folder to host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ env.uberspace_host }}
+          username: ${{ env.uberspace_user }}
+          key: ${{ secrets.SSH_KEY }}
+          port: 22
+          timeout: 1m
+          command_timeout: 2m
+          target: ${{ env.uberspace_virtual_base }}/${{ env.uberspace_user }}/${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}
+          source: "public/*"
+          rm: true
+          strip_components: 1
+
+      - name: Inform about preview removal
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          header: pr-preview
+          message: |
+            Pull Request Live Preview
+            :---:
+            | <p><br />:x: Preview has been removed.<br /><br /></p>

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -26,6 +26,11 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-22.04
+    # Set environment variables
+    env:
+      domain: openrailassociation.org
+      preview_subdomain: web-preview
+      preview_segment: pr-${{ github.event.number }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,8 +43,13 @@ jobs:
           hugo-version: "0.132.2"
           extended: true
 
-      - name: Build
+      - name: Build production site
         run: hugo
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build preview site
+        run: hugo -b https://${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}/
+        if: ${{ github.event.pull_request }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -49,47 +59,47 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  # Checking links using lychee
-  linkchecker:
-    runs-on: ubuntu-22.04
-    needs: build
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: public
-          path: .
+  # # Checking links using lychee
+  # linkchecker:
+  #   runs-on: ubuntu-22.04
+  #   needs: build
+  #   steps:
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: public
+  #         path: .
 
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v1
-        with:
-          args: '-r 5 -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple WebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" --exclude sncf.com --exclude nge.flatland.cloud --max-concurrency 1 .'
-          # Fail on errors
-          fail: false
-          # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
+  #     - name: Link Checker
+  #       id: lychee
+  #       uses: lycheeverse/lychee-action@v1
+  #       with:
+  #         args: '-r 5 -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple WebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" --exclude sncf.com --exclude nge.flatland.cloud --max-concurrency 1 .'
+  #         # Fail on errors
+  #         fail: false
+  #         # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04
-    needs: build
-    # Only deploy if on main branch
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: public
-          path: ./public
+  # # Deployment job
+  # deploy:
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-22.04
+  #   needs: build
+  #   # Only deploy if on main branch
+  #   if: github.ref == 'refs/heads/main'
+  #   steps:
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: public
+  #         path: ./public
 
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./public
+  #     - name: Upload pages artifact
+  #       uses: actions/upload-pages-artifact@v3
+  #       with:
+  #         path: ./public
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v4

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -84,25 +84,28 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  # # Checking links using lychee
-  # linkchecker:
-  #   runs-on: ubuntu-22.04
-  #   needs: build
-  #   steps:
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: public
-  #         path: .
+  # Checking links using lychee
+  linkchecker:
+    runs-on: ubuntu-22.04
+    needs:
+      - vars
+      - build
+    if: needs.vars.outputs.pr_closed_merged == 'false'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: .
 
-  #     - name: Link Checker
-  #       id: lychee
-  #       uses: lycheeverse/lychee-action@v1
-  #       with:
-  #         args: '-r 5 -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple WebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" --exclude sncf.com --exclude nge.flatland.cloud --max-concurrency 1 .'
-  #         # Fail on errors
-  #         fail: false
-  #         # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: '-r 5 -u "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple WebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" --include-fragments --exclude sncf.com --exclude nge.flatland.cloud --max-concurrency 1 .'
+          # Fail on errors
+          fail: false
+          # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
 
   # Deployment jobs
   deploy-production:

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -19,18 +19,22 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: "preview-pages"
   cancel-in-progress: false
+
+# Set environment variables
+env:
+  domain: openrailassociation.org
+  preview_subdomain: web-preview
+  preview_segment: pr-${{ github.event.number }}
+  uberspace_host: uberspace1.openrailassociation.org
+  uberspace_user: openrail
+  uberspace_virtual_base: /var/www/virtual
 
 jobs:
   # Build job
   build:
     runs-on: ubuntu-22.04
-    # Set environment variables
-    env:
-      domain: openrailassociation.org
-      preview_subdomain: web-preview
-      preview_segment: pr-${{ github.event.number }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,27 +83,53 @@ jobs:
   #         fail: false
   #         # TODO: Implement https://github.com/lycheeverse/lychee/issues/989 once it's done. Will help with LinkedIn rate limits
 
-  # # Deployment job
-  # deploy:
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-22.04
-  #   needs: build
-  #   # Only deploy if on main branch
-  #   if: github.ref == 'refs/heads/main'
-  #   steps:
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: public
-  #         path: ./public
+  # Deployment jobs
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: build
+    # Only deploy if on main branch
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: ./public
 
-  #     - name: Upload pages artifact
-  #       uses: actions/upload-pages-artifact@v3
-  #       with:
-  #         path: ./public
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
 
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-preview:
+    runs-on: ubuntu-22.04
+    needs: build
+    # Only deploy if pull request
+    if: ${{ github.event.pull_request }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: ./public
+
+      - name: Copy website to host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ env.uberspace_host }}
+          username: ${{ env.uberspace_user }}
+          key: ${{ secrets.SSH_KEY }}
+          port: 22
+          timeout: 1m
+          command_timeout: 2m
+          target: ${{ env.uberspace_virtual_base }}/${{ env.uberspace_user }}/${{ env.preview_subdomain }}.${{ env.domain }}/${{ env.preview_segment }}
+          source: "public/*"
+          rm: true
+          strip_components: 1


### PR DESCRIPTION
Allows to preview a PR. Also takes care of cleanup.

The location for this preview site is not Github Pages to avoid potential issues, but a separate webspace.

Replacement of #63 