### PR TITLE
Use relative URLs for news

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,7 +25,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "preview-pages"
+  group: "pages"
   cancel-in-progress: false
 
 # Set environment variables

--- a/themes/openrail/layouts/news/list.html
+++ b/themes/openrail/layouts/news/list.html
@@ -23,7 +23,7 @@
       <section class="news-list spotlight style2 orient-left content-align-left {{ .Params.image.class }}">
         <div class="inner medium">
           <header>
-            <h3><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
+            <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             <p>{{ .Date.Format "02 January 2006" }}</p>
           </header>
           <p>{{ .Summary }} <a href="{{ .RelPermalink }}"><br /><strong>Continue reading »</strong></a></p>


### PR DESCRIPTION
Fixes linkchecker in PRs.

Not ideal, some errors may still occur because of the redirection files like `credits.html` but it's much less.