### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 OpenRail Association AISBL
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: CI security tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          inputs: .github # excludes workflow files from 3rd parties, e.g. in themes

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -28,6 +28,9 @@ env:
   condition_production: ${{ github.ref == 'refs/heads/main' }}
   dir_preview_subdir: main-pr-${{ github.event.number }}
 
+permissions:
+  contents: read # For checkout
+
 jobs:
   # Build job
   build:
@@ -37,6 +40,7 @@ jobs:
         with:
           submodules: recursive # Get submodules
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+          persist-credentials: false
 
       - name: Setup required build tools with mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -46,7 +50,9 @@ jobs:
         if: env.condition_production == 'true'
 
       - name: Build preview site
-        run: hugo -s ${{ env.source_dir }} -e staging --buildFuture --buildDrafts -b ${{ vars.WEB_DOMAIN_PREVIEW }}/${{ env.dir_preview_subdir }}/
+        env:
+          VARS_WEB_DOMAIN_PREVIEW: ${{ vars.WEB_DOMAIN_PREVIEW }}
+        run: hugo -s ${{ env.source_dir }} -e staging --buildFuture --buildDrafts -b ${VARS_WEB_DOMAIN_PREVIEW}/${dir_preview_subdir}/
         if: github.event.pull_request
 
       - name: Upload artifact


### PR DESCRIPTION
Add CI security workflow using zizmor to scan GitHub Actions workflows for security issues.