### PR TITLE
ci: restrict some workflows to only run upstream

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    if: github.repository == 'OpenRailAssociation/website'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Adds `if: github.repository == '...'` condition to release-please, ci-security, and/or release-vulnerabilities workflows so they only run in the upstream repository, not in forks.